### PR TITLE
Remove attempt to close an already closed file handler

### DIFF
--- a/lib/php/admin/getIconMarker.php
+++ b/lib/php/admin/getIconMarker.php
@@ -9,14 +9,11 @@
 			array_push($tab, trim(fgets($handle, 4096)));
 		}
 		fclose($handle);
-	}
-	if ($handle){
 		foreach($tab as $cle => $valeur) { 
 			$temp_css = explode('{', $valeur);
 			$icon_css = substr($temp_css[0],1);
 			array_push($temp, $icon_css);
 		}
-		fclose($handle);
 	}
 	sort($temp);
 	array_shift($temp);


### PR DESCRIPTION
I encountered an issue with my php setup set to `display_errors` that gave me an incorrect response with a warning in it.
As an administrator, in Categories menu, double-click on an icon in the category table to modify it. This displays a drop-down list. Expanding the list triggers a request to `getIconMarker.php?case=category`.
The response content starts with this warning:
```
Warning: fclose(): supplied resource is not a valid stream resource in /velobs/lib/php/admin/getIconMarker.php on line 19
```
This is a legit warning as the code tries to close the file handle twice and `fclose` needs a valid file pointer.